### PR TITLE
login API 개발 및 Swagger Response 필드 추가

### DIFF
--- a/src/main/java/hyundai/hyundai/ExceptionHandler/BaseResponse.java
+++ b/src/main/java/hyundai/hyundai/ExceptionHandler/BaseResponse.java
@@ -2,6 +2,7 @@ package hyundai.hyundai.ExceptionHandler;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,11 +11,13 @@ import lombok.Getter;
 @JsonPropertyOrder({"message"})
 public class BaseResponse<T> {
 
+    @ApiModelProperty(example =  "요청에 성공했습니다.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String message;
     private T result;
 
     // 요청에 성공한 경우1 : Response 미포함
+
     public BaseResponse(){
         this.message = BaseResponseStatus.SUCCESS.getMessage();
     }

--- a/src/main/java/hyundai/hyundai/ExceptionHandler/BaseResponseStatus.java
+++ b/src/main/java/hyundai/hyundai/ExceptionHandler/BaseResponseStatus.java
@@ -10,7 +10,8 @@ public enum BaseResponseStatus {
     INVALID_PASSWORD_FORM("비밀번호 형식을 확인해주세요"),
     NOT_EQUAL_PASSWORD_REPASSWORD("비밀번호는 숫자,문자를 모두 포함하며, 8자~20자 사이로 입력해주세요"),
 
-    SERVER_ERROR("서버와의 연동에 실패했습니다.");
+    SERVER_ERROR("서버와의 연동에 실패했습니다"),
+    NOT_EXISTS_USER("이메일 또는 비밀번호가 잘못되었습니다");
 
     private final String message;
     private BaseResponseStatus(String message){

--- a/src/main/java/hyundai/hyundai/User/UserController.java
+++ b/src/main/java/hyundai/hyundai/User/UserController.java
@@ -4,6 +4,7 @@ import hyundai.hyundai.ExceptionHandler.BaseException;
 import hyundai.hyundai.ExceptionHandler.BaseResponse;
 import hyundai.hyundai.User.model.SignupUserReq;
 import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +22,7 @@ public class UserController {
 
     @ResponseBody
     @PostMapping("/signup")
+    @Operation(summary = "회원가입", description = "email, password 필드 값을 정상적인 값을 입력받도록 Regex(정규 표현식)을 사용했다는점 참고 해주세요!")
     public BaseResponse createUser(@RequestBody SignupUserReq signupUserReq){
         try{
             userService.createUser(signupUserReq);

--- a/src/main/java/hyundai/hyundai/User/UserController.java
+++ b/src/main/java/hyundai/hyundai/User/UserController.java
@@ -2,6 +2,8 @@ package hyundai.hyundai.User;
 
 import hyundai.hyundai.ExceptionHandler.BaseException;
 import hyundai.hyundai.ExceptionHandler.BaseResponse;
+import hyundai.hyundai.User.model.LoginUserReq;
+import hyundai.hyundai.User.model.LoginUserRes;
 import hyundai.hyundai.User.model.SignupUserReq;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,6 +31,18 @@ public class UserController {
             return new BaseResponse();
         } catch (BaseException exception){
             return new BaseResponse(exception.getStatus());
+        }
+    }
+
+    @ResponseBody
+    @GetMapping("/login")
+    @Operation(summary = "로그인", description = "Token이 아닌, userIdx(user pk값)를 리턴해주는 방식")
+    public BaseResponse<LoginUserRes> login(@RequestBody LoginUserReq loginUserReq){
+        try{
+            LoginUserRes loginUserRes = userService.login(loginUserReq);
+            return new BaseResponse(loginUserRes);
+        } catch (BaseException exception){
+            return new BaseResponse<LoginUserRes>(exception.getStatus());
         }
     }
 }

--- a/src/main/java/hyundai/hyundai/User/UserRepository.java
+++ b/src/main/java/hyundai/hyundai/User/UserRepository.java
@@ -1,9 +1,15 @@
 package hyundai.hyundai.User;
 
+import hyundai.hyundai.User.model.LoginUserRes;
 import hyundai.hyundai.User.model.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.repository.query.Param;
 
 @EnableJpaRepositories
 public interface UserRepository extends JpaRepository<UserEntity, Integer> {
+
+    @Query("select new hyundai.hyundai.User.model.LoginUserRes(m.userIdx) from UserEntity m where m.email = :email and m.password = :password")
+    LoginUserRes findUser(@Param("email") String email, @Param("password") String password);
 }

--- a/src/main/java/hyundai/hyundai/User/UserService.java
+++ b/src/main/java/hyundai/hyundai/User/UserService.java
@@ -3,6 +3,8 @@ package hyundai.hyundai.User;
 import hyundai.hyundai.ExceptionHandler.BaseException;
 import hyundai.hyundai.ExceptionHandler.BaseResponseStatus;
 import hyundai.hyundai.ExceptionHandler.Validation.CheckValidForm;
+import hyundai.hyundai.User.model.LoginUserReq;
+import hyundai.hyundai.User.model.LoginUserRes;
 import hyundai.hyundai.User.model.SignupUserReq;
 import hyundai.hyundai.User.model.UserEntity;
 import org.springframework.stereotype.Service;
@@ -41,6 +43,15 @@ public class UserService {
             userRepository.save(userEntity);
         } catch (Exception exception){
             throw new BaseException(BaseResponseStatus.SERVER_ERROR);
+        }
+    }
+
+    public LoginUserRes login(LoginUserReq loginUserReq) throws BaseException{
+        try{
+            LoginUserRes loginUserRes = userRepository.findUser(loginUserReq.getEmail(), loginUserReq.getPassword());
+            return new LoginUserRes(loginUserRes.getUserIdx());
+        } catch (Exception exception){
+            throw new BaseException(BaseResponseStatus.NOT_EXISTS_USER);
         }
     }
 }

--- a/src/main/java/hyundai/hyundai/User/model/LoginUserReq.java
+++ b/src/main/java/hyundai/hyundai/User/model/LoginUserReq.java
@@ -1,0 +1,13 @@
+package hyundai.hyundai.User.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginUserReq {
+    private String email;
+    private String password;
+}

--- a/src/main/java/hyundai/hyundai/User/model/LoginUserReq.java
+++ b/src/main/java/hyundai/hyundai/User/model/LoginUserReq.java
@@ -1,5 +1,6 @@
 package hyundai.hyundai.User.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginUserReq {
+
+    @ApiModelProperty(example = "msung99@naver.com")
     private String email;
+
+    @ApiModelProperty(example = "mypassword")
     private String password;
 }

--- a/src/main/java/hyundai/hyundai/User/model/LoginUserRes.java
+++ b/src/main/java/hyundai/hyundai/User/model/LoginUserRes.java
@@ -1,0 +1,12 @@
+package hyundai.hyundai.User.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LoginUserRes {
+    int userIdx;
+}

--- a/src/main/java/hyundai/hyundai/User/model/LoginUserRes.java
+++ b/src/main/java/hyundai/hyundai/User/model/LoginUserRes.java
@@ -1,5 +1,6 @@
 package hyundai.hyundai.User.model;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginUserRes {
+
+    @ApiModelProperty(example = "3")
     int userIdx;
 }


### PR DESCRIPTION
로그인API 는 토큰을 사용하지 않음에 따라, 간단하게 userIdx 를 리턴하는 방식으로 구현했습니다.

이에 해당하는 JPQL 문은 다음과 같습니다.

~~~java
@Query("select new hyundai.hyundai.User.model.LoginUserRes(m.userIdx) from UserEntity m where m.email = :email and m.password = :password")
    LoginUserRes findUser(@Param("email") String email, @Param("password") String password);
~~~